### PR TITLE
Change RootFS for tcp-sample-receiver to speed up tests

### DIFF
--- a/assets/tcp-sample-receiver/Dockerfile
+++ b/assets/tcp-sample-receiver/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudfoundry/trusty64
+FROM busybox:ubuntu-14.04
 RUN mkdir -p /run
 ADD https://s3.amazonaws.com/router-release-blobs/tcp-sample-receiver.linux /run/tcp-sample-receiver
 RUN chmod 755 /run/tcp-sample-receiver


### PR DESCRIPTION
`ltc test -v` is slow to load the RootFS for the new tcp-router spec.  Further investigation shows this docker image is about 725MB.  This changes the RootFS to the same as is used for `cloudfoundry/lattice-app`, the `busybox:ubuntu-14.04` base image.  Since we ask lattice users to always run `ltc test` after provisioning a cluster,  this will be very slow to those on slower network links.  `f4fadd672668` (11MB) below is the same image following the change, and I tested it still works.

Please consider this merge, and `docker build` / `docker push` to DockerHub repo if you approve.  

Regards,
David

```
22:02 $ docker images
REPOSITORY                         TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
<none>                             <none>              f4fadd672668        12 minutes ago      10.67 MB
cloudfoundry/tcp-sample-receiver   latest              bd800a630015        8 days ago          722.4 MB
cloudfoundry/lattice-app           latest              272ae80e1af6        12 weeks ago        19.6 MB
```

```
22:01 $ docker history cloudfoundry/tcp-sample-receiver
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
bd800a630015        8 days ago          /bin/sh -c #(nop) CMD ["/bin/sh" "-c" "/run/t   0 B
3cfda1b20738        8 days ago          /bin/sh -c #(nop) EXPOSE 5222/tcp               0 B
19b97ee2c0f5        8 days ago          /bin/sh -c chmod 755 /run/tcp-sample-receiver   2.532 MB
9a57cf025422        8 days ago          /bin/sh -c #(nop) ADD tarsum+sha256:711bd7e62   2.532 MB
5f01d79eef83        8 days ago          /bin/sh -c mkdir -p /run                        0 B
3b10024dd1af        5 months ago        /bin/sh -c rm -rf /tmp/*                        0 B
86b267c158ee        5 months ago        /bin/sh -c bash /tmp/build/configure-firstboo   410 B
24a8863096a0        5 months ago        /bin/sh -c bash /tmp/build/configure-core-dum   0 B
195f47f12a0e        5 months ago        /bin/sh -c bash /tmp/build/install-ruby.sh 1.   60.22 MB
ca68c74ccf02        5 months ago        /bin/sh -c bash /tmp/build/install-packages.s   463.8 MB
afd3a4d96f77        5 months ago        /bin/sh -c bash /tmp/build/configure-locale-t   4.96 MB
41e9ccf865ff        5 months ago        /bin/sh -c #(nop) ADD dir:10065071bbb4547edf3   693 B
8f333171568f        5 months ago        /bin/sh -c #(nop) ADD dir:a1f15f4186299e69d6b   3.867 kB
5ba9dab47459        6 months ago        /bin/sh -c #(nop) CMD [/bin/bash]               0 B
51a9c7c1f8bb        6 months ago        /bin/sh -c sed -i 's/^#\s*\(deb.*universe\)$/   1.895 kB
5f92234dcf1e        6 months ago        /bin/sh -c echo '#!/bin/sh' > /usr/sbin/polic   194.5 kB
27d47432a69b        6 months ago        /bin/sh -c #(nop) ADD file:62400a49cced0d7521   188.1 MB
511136ea3c5a        2 years ago                                                         0 B                 Imported from -
```
